### PR TITLE
Email fill script does not work on Windows

### DIFF
--- a/scripts/autofill-feedback-email.js
+++ b/scripts/autofill-feedback-email.js
@@ -38,7 +38,7 @@ if (isCI) {
     }
     const options = {
       files: [path.join(__dirname, '..', 'src/**/*.js')],
-      from: /&em=\n/,
+      from: /&em=\r?\n/,
       to: `&em=${email}\n`,
     }
 


### PR DESCRIPTION
Tested this and it works locally on Windows 10 with vscode. Would need someone to test the regex on Mac as I don't have one.

I imagine this could be done to the other projects as I remember having this issue in learn-react-hooks as well.