### PR TITLE
Remove reference to useCount in 03.md

### DIFF
--- a/src/exercises/03.md
+++ b/src/exercises/03.md
@@ -65,8 +65,8 @@ parts of the tree. Normally lifting state up would be the way to solve this
 trivial problem, but this is a contrived example so you can focus on learning
 how to use context.
 
-Your job is to fill in the `CountProvider` function component and `useCount`
-custom hook so that the app works and the tests pass.
+Your job is to fill in the `CountProvider` function component so that the app 
+works and the tests pass.
 
 ## 🦉 Other notes
 


### PR DESCRIPTION
`useCount` isn't mentioned anywhere except this line. Dunno if you wanted to make a `useCount` hook as extra credit, but as it is now, this is a bit confusing.