### PR TITLE
Remove step from initial state of  01 exercise

### DIFF
--- a/src/exercise/01.js
+++ b/src/exercise/01.js
@@ -12,7 +12,7 @@ function Counter({initialCount = 0, step = 1}) {
   // changes to the next two lines of code! Remember:
   // The 1st argument is called "state" - the current value of count
   // The 2nd argument is called "action" - the value passed to setCount
-  const increment = () => setCount(count + step)
+  const increment = () => setCount(count + 1)
   return <button onClick={increment}>{count}</button>
 }
 


### PR DESCRIPTION
Not sure if this is a big deal, but in the Solution video for the first exercise you have `1` being passed instead of `step` to `setCount`

PRing for consistency unless this was intentional!

![](https://media0.giphy.com/media/NMufrvxO8fC3C/giphy.gif?cid=5a38a5a22305f67c4930b1fd86ad6a07f4876b7484a79572&rid=giphy.gif)
