### PR TITLE
Reset exercise 05 to not have solution

### DIFF
--- a/src/exercise/05.js
+++ b/src/exercise/05.js
@@ -3,23 +3,23 @@
 
 import React from 'react'
 
-function MessagesDisplay({messages}, ref) {
+// 🐨 wrap this in a React.forwardRef and accept `ref` as the second argument
+function MessagesDisplay({messages}) {
   const containerRef = React.useRef()
   React.useLayoutEffect(() => {
     scrollToBottom()
   })
 
-  function scrollToTop() {
-    containerRef.current.scrollTop = 0
-  }
+  // 💰 you're gonna want this as part of your imperative methods
+  // function scrollToTop() {
+  //   containerRef.current.scrollTop = 0
+  // }
   function scrollToBottom() {
     containerRef.current.scrollTop = containerRef.current.scrollHeight
   }
 
-  React.useImperativeHandle(ref, () => ({
-    scrollToTop,
-    scrollToBottom,
-  }))
+  // 🐨 call useImperativeHandle here with your ref and a callback function
+  // that returns an object with scrollToTop and scrollToBottom
 
   return (
     <div ref={containerRef} role="log">
@@ -32,8 +32,6 @@ function MessagesDisplay({messages}, ref) {
     </div>
   )
 }
-// eslint-disable-next-line no-func-assign
-MessagesDisplay = React.forwardRef(MessagesDisplay)
 
 function App() {
   const messageDisplayRef = React.useRef()


### PR DESCRIPTION
Sorry for all the noise today 😜   It looks like [this commit](https://github.com/zacjones93/advanced-react-hooks/commit/5af5761674497603bb907cf943ae2b99778d2748) was only intended to update exercise 06 but exercise 05 got updated to its final solution with all the inline prompts removed. 

## Changes made
- resets exercise 5 to the actual exercise vs having the solution.

The recorded `useImperativeHandle: Scroll to top/bottom` intro lesson would also confirm that the current state of the exercise is incorrect and needs to be reset. The intro shows the prompts that were removed in the above commit,

Here's a screenshot of the diff from the commit that set the solution as the exercise:
![Image 2020-07-28 at 3 24 04 PM](https://user-images.githubusercontent.com/6188161/88712292-79572b00-d0e7-11ea-9465-b078342cfac7.png)


![](https://media0.giphy.com/media/sChf4Eo55W8x2/giphy.gif?cid=5a38a5a27dil50kob8w53gba65my8cmkwhbqsdtpbwjwqmqo&rid=giphy.gif)
