### PR TITLE
Fix small typo in 06.md

### DIFF
--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -65,7 +65,7 @@ function useCount({initialCount = 0, step = 1} = {}) {
 
 This is only really useful for situations where computing the debug value is
 computationally expensive (and therefore you only want it calculated when the
-devtools are open and not when your users are using the app). In our case this
+DevTools are open and not when your users are using the app). In our case this
 is not necessary, however go ahead and give it a try anyway.
 
 ## 🦉 Elaboration and Feedback

--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -22,7 +22,7 @@ function useCount({initialCount = 0, step = 1} = {}) {
 So now when people use the `useCount` hook, they'll see the `initialCount` and
 `step` values for that particular hook.
 
-## Exercise
+## Exercise 
 
 In this exercise, we have a custom `useMedia` hook which uses
 `window.matchMedia` to determine whether the user-agent satisfies a given media

--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -22,7 +22,7 @@ function useCount({initialCount = 0, step = 1} = {}) {
 So now when people use the `useCount` hook, they'll see the `initialCount` and
 `step` values for that particular hook.
 
-## Exercise 
+## Exercise
 
 In this exercise, we have a custom `useMedia` hook which uses
 `window.matchMedia` to determine whether the user-agent satisfies a given media


### PR DESCRIPTION
• `devtools` -> `DevTools` (to be more consistent with the other references)