### PR TITLE
Use the `step` variable so it matches the examples

### DIFF
--- a/src/final/01.extra-2.js
+++ b/src/final/01.extra-2.js
@@ -11,7 +11,7 @@ function Counter({initialCount = 0, step = 1}) {
     count: initialCount,
   })
   const {count} = state
-  const increment = () => setState({count: count + 1})
+  const increment = () => setState({count: count + step})
   return <button onClick={increment}>{count}</button>
 }
 

--- a/src/final/01.extra-3.js
+++ b/src/final/01.extra-3.js
@@ -15,7 +15,7 @@ function Counter({initialCount = 0, step = 1}) {
   })
   const {count} = state
   const increment = () =>
-    setState(currentState => ({count: currentState.count + 1}))
+    setState(currentState => ({count: currentState.count + step}))
   return <button onClick={increment}>{count}</button>
 }
 


### PR DESCRIPTION
Hello! I noticed a small difference between the examples in the markdown file and the final code and I just went and fixed it. There are no notable changes in behavior since `step` has a default value of `1`.
 