### PR TITLE
fix: disable new jsx transform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6118,6 +6118,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-error-boundary": "^3.0.2"
   },
   "devDependencies": {
+    "cross-env": "^7.0.2",
     "husky": "^4.3.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.2",
@@ -32,9 +33,9 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
-    "test:coverage": "npm run test -- --watchAll=false",
-    "test:exercises": "npm run test -- testing.*exercises\\/ --onlyChanged",
+    "test": "cross-env DISABLE_NEW_JSX_TRANSFORM=true react-scripts test",
+    "test:coverage": "cross-env DISABLE_NEW_JSX_TRANSFORM=true npm run test -- --watchAll=false",
+    "test:exercises": "cross-env DISABLE_NEW_JSX_TRANSFORM=true npm run test -- testing.*exercises\\/ --onlyChanged",
     "setup": "node setup",
     "lint": "eslint .",
     "validate": "npm-run-all --parallel build test:coverage lint"


### PR DESCRIPTION
react-scripts@4.0.0 introduce new jsx transformer, because of that,
overiding React's `createElement` would not work anymore.

set env of `DISABLE_NEW_JSX_TRANSFORM` to keep using the old jsx
transform so that the tests would pass ([source][1])

it's a temporary solution

[1]: https://github.com/facebook/create-react-app/commit/2b1161b34641bb4d2f269661cd636bbcd4888406#diff-4f6f41a4cff8d78483f30bcf1befa1a002c4995cf9cd2ab6622eed82db48530cR13
