### PR TITLE
add test for scrolling to the bottom

### DIFF
--- a/src/__tests__/04.js
+++ b/src/__tests__/04.js
@@ -15,3 +15,34 @@ test('adds and removes children from the log', () => {
   userEvent.click(remove)
   expect(log.children).toHaveLength(chatCount)
 })
+
+test('scrolls to the bottom', () => {
+  const {getByText, getByRole} = render(<App />)
+  const log = getByRole('log')
+  const add = getByText(/add/i)
+  const remove = getByText(/remove/i)
+  const scrollTopSetter = jest.fn()
+  Object.defineProperties(log, {
+    scrollHeight: {
+      get() {
+        return 100
+      },
+    },
+    scrollTop: {
+      get() {
+        return 0
+      },
+      set: scrollTopSetter,
+    },
+  })
+
+  userEvent.click(add)
+  expect(scrollTopSetter).toHaveBeenCalledTimes(1)
+  expect(scrollTopSetter).toHaveBeenCalledWith(log.scrollHeight)
+
+  scrollTopSetter.mockClear()
+
+  userEvent.click(remove)
+  expect(scrollTopSetter).toHaveBeenCalledTimes(1)
+  expect(scrollTopSetter).toHaveBeenCalledWith(log.scrollHeight)
+})


### PR DESCRIPTION
The current tests for exercise 4 look prone to false positives compared to the other tests that break as soon as I import the initial version instead of the final version. I failed to achieve that because I had no idea how to let the test code notice the subtle difference between when using the `useLayoutEffect` hook and when using the `useEffect` hook. Nevertheless, the new test will fail while someone is making the transition for the exercise.