### PR TITLE
use addEventListener instead of addListener due to it's deprecated for MediaQueryList

### DIFF
--- a/src/exercise/06.js
+++ b/src/exercise/06.js
@@ -18,12 +18,12 @@ function useMedia(query, initialState = false) {
       setState(Boolean(mql.matches))
     }
 
-    mql.addListener(onChange)
+    mql.addEventListener("mediaChange", onChange)
     setState(mql.matches)
 
     return () => {
       mounted = false
-      mql.removeListener(onChange)
+      mql.removeEventListener("mediaChange", onChange)
     }
   }, [query])
 

--- a/src/final/06.extra-1.js
+++ b/src/final/06.extra-1.js
@@ -20,12 +20,12 @@ function useMedia(query, initialState = false) {
       setState(Boolean(mql.matches))
     }
 
-    mql.addListener(onChange)
+    mql.addEventListener("mediaChange", onChange)
     setState(mql.matches)
 
     return () => {
       mounted = false
-      mql.removeListener(onChange)
+      mql.removeEventListener("mediaChange", onChange)
     }
   }, [query])
 

--- a/src/final/06.js
+++ b/src/final/06.js
@@ -17,12 +17,12 @@ function useMedia(query, initialState = false) {
       setState(Boolean(mql.matches))
     }
 
-    mql.addListener(onChange)
+    mql.addEventListener("mediaChange", onChange)
     setState(mql.matches)
 
     return () => {
       mounted = false
-      mql.removeListener(onChange)
+      mql.removeEventListener("mediaChange", onChange)
     }
   }, [query])
 


### PR DESCRIPTION
`addListener()` method is deprecated, replaced it with recommended `addEventListener` method.

MDN refence: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener