### PR TITLE
test: Make sure to verify the extra credit button behavior

### DIFF
--- a/src/__tests__/01.js
+++ b/src/__tests__/01.js
@@ -12,6 +12,8 @@ test('clicking the button increments the count with useReducer', () => {
   const button = container.querySelector('button')
   userEvent.click(button)
   expect(button).toHaveTextContent('1')
+  userEvent.click(button)
+  expect(button).toHaveTextContent('2')
 
   alfredTip(() => {
     expect(React.useReducer).toHaveBeenCalled()


### PR DESCRIPTION
It might be nice to verify the button actually increases the existing value. If you start to implement the extra credit requirements you might accidentally set the count to "step". Then the test would still be green, it only fails when you try to click the button again…