### PR TITLE
Use `type` variable destructured from `action` object in `0.1extra-4.js`

### DIFF
--- a/src/exercise/01.md
+++ b/src/exercise/01.md
@@ -198,7 +198,7 @@ important.
 
 <div>
 <span>After the instruction, if you want to remember what you've just learned, then </span>
-<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=01%3A%20useReducer%3A%20simple%20Counter&em=aosantea%40ucenfotec.ac.cr">
+<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=01%3A%20useReducer%3A%20simple%20Counter&em=">
   fill out the elaboration and feedback form.
 </a>
 </div>

--- a/src/exercise/01.md
+++ b/src/exercise/01.md
@@ -198,7 +198,7 @@ important.
 
 <div>
 <span>After the instruction, if you want to remember what you've just learned, then </span>
-<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=01%3A%20useReducer%3A%20simple%20Counter&em=">
+<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=01%3A%20useReducer%3A%20simple%20Counter&em=aosantea%40ucenfotec.ac.cr">
   fill out the elaboration and feedback form.
 </a>
 </div>

--- a/src/exercise/02.md
+++ b/src/exercise/02.md
@@ -215,7 +215,7 @@ might need `useRef`, `useCallback`, and `useEffect`.
 
 <div>
 <span>After the instruction, if you want to remember what you've just learned, then </span>
-<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=02%3A%20useCallback%3A%20custom%20hooks&em=">
+<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=02%3A%20useCallback%3A%20custom%20hooks&em=aosantea%40ucenfotec.ac.cr">
   fill out the elaboration and feedback form.
 </a>
 </div>

--- a/src/exercise/03.md
+++ b/src/exercise/03.md
@@ -141,7 +141,7 @@ most has improved performance and maintainability characteristics.
 
 <div>
 <span>After the instruction, if you want to remember what you've just learned, then </span>
-<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=03%3A%20useContext%3A%20simple%20Counter&em=">
+<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=03%3A%20useContext%3A%20simple%20Counter&em=aosantea%40ucenfotec.ac.cr">
   fill out the elaboration and feedback form.
 </a>
 </div>

--- a/src/exercise/04.md
+++ b/src/exercise/04.md
@@ -36,7 +36,7 @@ making observable changes to the DOM, then it should happen in
 
 <div>
 <span>After the instruction, if you want to remember what you've just learned, then </span>
-<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=04%3A%20useLayoutEffect%3A%20auto-scrolling%20textarea&em=">
+<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=04%3A%20useLayoutEffect%3A%20auto-scrolling%20textarea&em=aosantea%40ucenfotec.ac.cr">
   fill out the elaboration and feedback form.
 </a>
 </div>

--- a/src/exercise/05.md
+++ b/src/exercise/05.md
@@ -95,7 +95,7 @@ parent component can call those directly.
 
 <div>
 <span>After the instruction, if you want to remember what you've just learned, then </span>
-<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=05%3A%20useImperativeHandle%3A%20scroll%20to%20top%2Fbottom&em=">
+<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=05%3A%20useImperativeHandle%3A%20scroll%20to%20top%2Fbottom&em=aosantea%40ucenfotec.ac.cr">
   fill out the elaboration and feedback form.
 </a>
 </div>

--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -72,7 +72,7 @@ is not necessary, however, go ahead and give it a try anyway.
 
 <div>
 <span>After the instruction, if you want to remember what you've just learned, then </span>
-<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=06%3A%20useDebugValue%3A%20useMedia&em=">
+<a rel="noopener noreferrer" target="_blank" href="https://ws.kcd.im/?ws=Advanced%20React%20Hooks%20%F0%9F%94%A5&e=06%3A%20useDebugValue%3A%20useMedia&em=aosantea%40ucenfotec.ac.cr">
   fill out the elaboration and feedback form.
 </a>
 </div>

--- a/src/final/01.extra-4.js
+++ b/src/final/01.extra-4.js
@@ -14,7 +14,7 @@ function countReducer(state, action) {
       }
     }
     default: {
-      throw new Error(`Unsupported action type: ${action.type}`)
+      throw new Error(`Unsupported action type: ${type}`)
     }
   }
 }


### PR DESCRIPTION
Very small "improvement"  here, but I thought id't be best if the destructured `type` variable was used for consistency. 