### PR TITLE
Fixed a typo in comments

### DIFF
--- a/src/exercise/03.extra-2.js
+++ b/src/exercise/03.extra-2.js
@@ -21,7 +21,7 @@ import {useAsync} from '../utils'
 // 🐨 useReducer with pokemonCacheReducer in your PokemonCacheProvider
 // 💰 you can grab the one that's in PokemonInfo
 // 🐨 return your context provider with the value assigned to what you get back from useReducer
-// 💰 value={[cache, dispatch]}
+// 💰 value=[cache, dispatch]
 // 💰 make sure you forward the props.children!
 
 function pokemonCacheReducer(state, action) {


### PR DESCRIPTION
Found a small typo in an exercise, it says 
` // :moneybag: value={[cache, dispatch]}`
 where it should be
`// :moneybag: value=[cache, dispatch]`