### PR TITLE
Use `type` variable destructured from `action` object in `0.1extra-4.js`

### DIFF
--- a/src/final/01.extra-4.js
+++ b/src/final/01.extra-4.js
@@ -14,7 +14,7 @@ function countReducer(state, action) {
       }
     }
     default: {
-      throw new Error(`Unsupported action type: ${action.type}`)
+      throw new Error(`Unsupported action type: ${type}`)
     }
   }
 }


### PR DESCRIPTION
Very small "improvement" here, but I thought id't be best if the destructured `type` variable was used for consistency.