### PR TITLE
refactor: deprecated addListener

### DIFF
--- a/src/exercise/06.js
+++ b/src/exercise/06.js
@@ -18,12 +18,12 @@ function useMedia(query, initialState = false) {
       setState(Boolean(mql.matches))
     }
 
-    mql.addListener(onChange)
+    mql.addEventListener("change", onChange)
     setState(mql.matches)
 
     return () => {
       mounted = false
-      mql.removeListener(onChange)
+      mql.removeEventListener("change", onChange)
     }
   }, [query])
 

--- a/src/exercise/06.js
+++ b/src/exercise/06.js
@@ -18,12 +18,12 @@ function useMedia(query, initialState = false) {
       setState(Boolean(mql.matches))
     }
 
-    mql.addEventListener("change", onChange)
+    mql.addEventListener('change', onChange)
     setState(mql.matches)
 
     return () => {
       mounted = false
-      mql.removeEventListener("change", onChange)
+      mql.removeEventListener('change', onChange)
     }
   }, [query])
 

--- a/src/final/06.js
+++ b/src/final/06.js
@@ -17,12 +17,12 @@ function useMedia(query, initialState = false) {
       setState(Boolean(mql.matches))
     }
 
-    mql.addListener(onChange)
+    mql.addEventListener("change", onChange)
     setState(mql.matches)
 
     return () => {
       mounted = false
-      mql.removeListener(onChange)
+      mql.removeEventListener("change", onChange)
     }
   }, [query])
 


### PR DESCRIPTION
In useDebugValue: useMedia exercise have the deprecated `addListener()` method of the MediaQueryList .


![image](https://user-images.githubusercontent.com/13061304/113902045-aec92200-97f9-11eb-8bfb-ff2e9b64157d.png)


We should use `addEventListener` with `change` event instead of `addListener`.

