### PR TITLE
Wrap in act() to avoid extraneous console.error

### DIFF
--- a/src/__tests__/02.extra-3.js
+++ b/src/__tests__/02.extra-3.js
@@ -4,6 +4,7 @@ import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import App from '../final/02.extra-3'
 // import App from '../exercise/02'
+import {act} from 'react-dom/test-utils'
 
 beforeEach(() => {
   jest.spyOn(window, 'fetch')
@@ -58,11 +59,14 @@ test('displays the pokemon', async () => {
 
   console.error.mockReset()
 
-  userEvent.type(input, 'mew')
-  userEvent.click(submit)
+  act(() => {
+    userEvent.type(input, 'mew')
+    userEvent.click(submit)
 
-  // verify unmounting does not result in an error
-  unmount()
+    // verify unmounting does not result in an error
+    unmount()
+  })
+
   // wait for a bit for the mocked request to resolve:
   await new Promise(r => setTimeout(r, 100))
   alfredTip(

--- a/src/__tests__/02.extra-3.js
+++ b/src/__tests__/02.extra-3.js
@@ -1,10 +1,9 @@
 import * as React from 'react'
 import {alfredTip} from '@kentcdodds/react-workshop-app/test-utils'
-import {render, screen} from '@testing-library/react'
+import {render, screen, act} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import App from '../final/02.extra-3'
 // import App from '../exercise/02'
-import {act} from 'react-dom/test-utils'
 
 beforeEach(() => {
   jest.spyOn(window, 'fetch')
@@ -57,18 +56,18 @@ test('displays the pokemon', async () => {
   )
   expect(console.error).toHaveBeenCalledTimes(2)
 
-  console.error.mockReset()
+  // restore the original implementation
+  console.error.mockRestore()
+  // but we still want to make sure it's not called
+  jest.spyOn(console, 'error')
 
-  act(() => {
-    userEvent.type(input, 'mew')
-    userEvent.click(submit)
+  userEvent.type(input, 'mew')
+  userEvent.click(submit)
 
-    // verify unmounting does not result in an error
-    unmount()
-  })
-
+  // verify unmounting does not result in an error
+  unmount()
   // wait for a bit for the mocked request to resolve:
-  await new Promise(r => setTimeout(r, 100))
+  await act(() => new Promise(r => setTimeout(r, 100)))
   alfredTip(
     () => expect(console.error).not.toHaveBeenCalled(),
     'Make sure that when the component is unmounted the component does not attempt to trigger a rerender with `dispatch`',


### PR DESCRIPTION
I was working through exercise 2-extra 3, and was having a hard time getting the tests to pass, even though my implementation seemed to work fine in the browser, without throwing an error.

I added a `useState` in `useAsync` to track whether or not the fetch should be considered cancelled, and added a `useEffect` in the component with a cleanup method to call the setter for that state.  The test failed on the last step, and when I replaced the `alfredTip` with a plain `expect(console.error).not.toHaveBeenCalled()` I could see this console error:


    expect(jest.fn()).not.toHaveBeenCalled()

    Expected number of calls: 0
    Received number of calls: 1

    1: "Warning: An update to %s inside a test was not wrapped in act(...).·
    When testing, code that causes React state updates should be wrapped into act(...):·
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */·
	...

Wrapping an `act()` around the click and the unmount removes the warning and lets the test pass.  This PR also wraps the `type`, just because that feels cleaner for some reason.

I know my solution wasn't the same as what KCD shows in the video (and it's not as good), but he _did_ leave the instructions vague on purpose, so it seems like the tests should accept anything that works.  😉  