### PR TITLE
fix test for useReducer, simpleCounter example

### DIFF
--- a/src/__tests__/01.js
+++ b/src/__tests__/01.js
@@ -26,7 +26,7 @@ test('clicking the button increments the count with useReducer', () => {
   alfredTip(() => {
     const commentLessLines = Counter.toString()
       .split('\n')
-      .filter(l => !l.includes('//'))
+      .filter(l => !l.trim().substr(0, 2).includes('//'))
       .join('\n')
     expect(commentLessLines).toMatch('useReducer(')
     expect(commentLessLines).not.toMatch('useState(')


### PR DESCRIPTION
The code that looks for "commentLessLines" ends up filtering unintended lines . `Counter.toString()` returns this:

```js
function Counter({
      initialCount = 0,
      step = 1
    }) {
      // 🐨 replace React.useState with React.useReducer.
      // 💰 React.useReducer(countReducer, initialCount)
      const [count, setCount] = React.useReducer(countReducer, initialCount); // 💰 you can write the countReducer function so you don't have to make any
      // changes to the next two lines of code! Remember:
      // The 1st argument is called "state" - the current value of count
      // The 2nd argument is called "newState" - the value passed to setCount
    
      const increment = () => setCount(count + step);
    
      return /*#__PURE__*/(0, _jsxDevRuntime.jsxDEV)("button", {
        onClick: increment,
        children: count
      }, void 0, false, {
        fileName: _jsxFileName,
        lineNumber: 18,
        columnNumber: 10
      }, this);
    }
```
As you can see, the non-comment code with `React.useReducer` is on a line that ends with a comment, but this whole line will be filtered out, and the test will fail. We might want to instead look for lines that begin with comments: `l.trim().substr(0, 2).includes('//')`

