### PR TITLE
Updated link to egghead.io on how to contribute to open source. 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,5 +34,5 @@ Also, please watch the repo and respond to questions/bug reports/feature
 requests! Thanks!
 
 [egghead]:
-  https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+  https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://github.com/kentcdodds/advanced-react-hooks/issues


### PR DESCRIPTION
Includes an updated link to the latest series on how to contribute to open source.