### PR TITLE
fix pokemonName case sensitivity

### DIFF
--- a/src/exercise/03.extra-2.js
+++ b/src/exercise/03.extra-2.js
@@ -40,8 +40,8 @@ function PokemonInfo({pokemonName: externalPokemonName}) {
   const [cache, dispatch] = React.useReducer(pokemonCacheReducer, {})
   // 🐨 get the cache and dispatch from useContext with PokemonCacheContext
 
-  const {data: pokemon, status, error, run, setData} = useAsync()
   const pokemonName = externalPokemonName?.toLowerCase()
+  const {data: pokemon, status, error, run, setData} = useAsync()
 
   React.useEffect(() => {
     if (!pokemonName) {

--- a/src/exercise/03.extra-2.js
+++ b/src/exercise/03.extra-2.js
@@ -35,12 +35,13 @@ function pokemonCacheReducer(state, action) {
   }
 }
 
-function PokemonInfo({pokemonName}) {
+function PokemonInfo({pokemonName: externalPokemonName}) {
   // 💣 remove the useReducer here (or move it up to your PokemonCacheProvider)
   const [cache, dispatch] = React.useReducer(pokemonCacheReducer, {})
   // 🐨 get the cache and dispatch from useContext with PokemonCacheContext
 
   const {data: pokemon, status, error, run, setData} = useAsync()
+  const pokemonName = externalPokemonName?.toLowerCase()
 
   React.useEffect(() => {
     if (!pokemonName) {


### PR DESCRIPTION
`pokemonName` should be case insensitive to avoid multiple cache entries for searches like "Charizard", "CHARIZARD", "charizard" etc.