### PR TITLE
fix pokemonName case sensitivity

### DIFF
--- a/src/final/03.extra-2.js
+++ b/src/final/03.extra-2.js
@@ -45,12 +45,12 @@ function usePokemonCache() {
 
 function PokemonInfo({pokemonName: externalPokemonName}) {
   const [cache, dispatch] = usePokemonCache()
-
+  
+  const pokemonName = externalPokemonName?.toLowerCase()
   const {data: pokemon, status, error, run, setData} = useAsync({
     status: pokemonName ? 'pending' : 'idle',
   })
-  const pokemonName = externalPokemonName?.toLowerCase()
-
+  
   React.useEffect(() => {
     if (!pokemonName) {
       return

--- a/src/final/03.extra-2.js
+++ b/src/final/03.extra-2.js
@@ -43,12 +43,13 @@ function usePokemonCache() {
   return context
 }
 
-function PokemonInfo({pokemonName}) {
+function PokemonInfo({pokemonName: externalPokemonName}) {
   const [cache, dispatch] = usePokemonCache()
 
   const {data: pokemon, status, error, run, setData} = useAsync({
     status: pokemonName ? 'pending' : 'idle',
   })
+  const pokemonName = externalPokemonName?.toLowerCase()
 
   React.useEffect(() => {
     if (!pokemonName) {


### PR DESCRIPTION
`pokemonName` should be case insensitive to avoid multiple cache entries for searches like "Charizard", "CHARIZARD", "charizard" etc.