### PR TITLE
Fix typescript syntax highlighting

### DIFF
--- a/src/exercise/02.md
+++ b/src/exercise/02.md
@@ -13,7 +13,7 @@ recompute a value for a given input by storing the original computation and
 returning that stored value when the same input is provided. Caching is a form
 of memoization. Here's a simple implementation of memoization:
 
-```ts
+```typescript
 const values = {}
 function addOne(num: number) {
   if (values[num] === undefined) {
@@ -25,7 +25,7 @@ function addOne(num: number) {
 
 One other aspect of memoization is value referential equality. For example:
 
-```ts
+```typescript
 const dog1 = new Dog('sam')
 const dog2 = new Dog('sam')
 console.log(dog1 === dog2) // false
@@ -34,7 +34,7 @@ console.log(dog1 === dog2) // false
 Even though those two dogs have the same name, they are not the same. However,
 we can use memoization to get the same dog:
 
-```ts
+```typescript
 const dogs = {}
 function getDog(name: string) {
   if (dogs[name] === undefined) {
@@ -51,7 +51,7 @@ console.log(dog1 === dog2) // true
 You might have noticed that our memoization examples look very similar.
 Memoization is something you can implement as a generic abstraction:
 
-```ts
+```typescript
 function memoize<ArgType, ReturnValue>(cb: (arg: ArgType) => ReturnValue) {
   const cache: Record<ArgType, ReturnValue> = {}
   return function memoized(arg: ArgType) {
@@ -174,7 +174,7 @@ React only gives us the new one if the dependency list changes.
 In this exercise, we're going to be using `useCallback`, but `useCallback` is
 just a shortcut to using `useMemo` for functions:
 
-```ts
+```typescript
 // the useMemo version:
 const updateLocalStorage = React.useMemo(
   // useCallback saves us from this annoying double-arrow function thing:


### PR DESCRIPTION
The typescript syntax in code blocks were not being highlighted. I checked in Firefox Developer Edition (96.0b6 ) and Google Chrome (Version 96.0.4664.110). 