### PR TITLE
Replace deprecated matchMedia methods by event listeners

### DIFF
--- a/src/exercise/06.js
+++ b/src/exercise/06.js
@@ -18,12 +18,12 @@ function useMedia(query, initialState = false) {
       setState(Boolean(mql.matches))
     }
 
-    mql.addListener(onChange)
+    mql.addEventListener('change', onChange)
     setState(mql.matches)
 
     return () => {
       mounted = false
-      mql.removeListener(onChange)
+      mql.removeEventListener('change', onChange)
     }
   }, [query])
 

--- a/src/final/06.extra-1.js
+++ b/src/final/06.extra-1.js
@@ -20,12 +20,12 @@ function useMedia(query, initialState = false) {
       setState(Boolean(mql.matches))
     }
 
-    mql.addListener(onChange)
+    mql.addEventListener('change', onChange)
     setState(mql.matches)
 
     return () => {
       mounted = false
-      mql.removeListener(onChange)
+      mql.removeListener('change', onChange)
     }
   }, [query])
 

--- a/src/final/06.js
+++ b/src/final/06.js
@@ -17,12 +17,12 @@ function useMedia(query, initialState = false) {
       setState(Boolean(mql.matches))
     }
 
-    mql.addListener(onChange)
+    mql.addEventListener('change', onChange)
     setState(mql.matches)
 
     return () => {
       mounted = false
-      mql.removeListener(onChange)
+      mql.removeEventListener('change', onChange)
     }
   }, [query])
 


### PR DESCRIPTION
Hello,

`addListener` and `removeListener` methods have been deprecated from the `MediaQueryList` interface so I replaced them with a change event listener on exercise 6.

[See MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#methods)