### PR TITLE
Pre not rendering, swapped to code block

### DIFF
--- a/src/exercise/02.md
+++ b/src/exercise/02.md
@@ -352,7 +352,7 @@ it will call `dispatch`, but because the component has been removed from the
 page, we'll get this warning from React:
 
 ```text
-Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.</pre>
+Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
 ```
 
 The best solution to this problem would be to

--- a/src/exercise/02.md
+++ b/src/exercise/02.md
@@ -351,7 +351,9 @@ removed from the page ("unmounted") and when the request finally does complete,
 it will call `dispatch`, but because the component has been removed from the
 page, we'll get this warning from React:
 
-<pre style={{whiteSpace: 'normal'}}>Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.</pre>
+```text
+Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.</pre>
+```
 
 The best solution to this problem would be to
 [cancel the request](https://developers.google.com/web/updates/2017/09/abortable-fetch),


### PR DESCRIPTION
The `pre` element wasn't rendering the warning:

![Screen Shot 2022-09-29 at 11 56 23 AM](https://user-images.githubusercontent.com/26470581/193118778-cafbf99c-971a-4104-b359-10b625dd3d7e.png)

Swapping it to a code block fixes the rendering issue:

![Screen Shot 2022-09-29 at 11 55 59 AM](https://user-images.githubusercontent.com/26470581/193118788-2c4ad3a6-f8d3-4194-832c-4502569ef6cb.png)

![](https://media4.giphy.com/media/O7BtZQ0ceoVz4pDdC7/100.gif?cid=5a38a5a2zgkyq72tq9kygza04v2c0pwu7pwy7xl9ynz2t77j&rid=100.gif&ct=g)