### PR TITLE
Elaborate on `useCount` usage for Extra Credit 1

### DIFF
--- a/src/exercise/03.md
+++ b/src/exercise/03.md
@@ -121,7 +121,7 @@ function App() {
 }
 ```
 
-It should throw an error indicating that `useCount` must be used within a
+It should throw an error indicating that `useCount` may only be used from within a (child of a)
 CountProvider.
 
 ### 2. 💯 caching in a context provider


### PR DESCRIPTION
This could just be my own misunderstanding, but when reading the original text:

> It should throw an error indicating that `useCount` must be used within a CountProvider.

I took this to mean that if you *must* use `useCount` within a `CountProvider`, and an error should be thrown if a call to `useCount` is not found, instead of `useCount` *can only be used* from within a `CountProvider`. 

I realise now this wouldn't have made much sense, but hopefully this can save someone else from needing to look at the answer to understanding what they need(ed) to do!