### PR TITLE
add deprecation warning to safe-dispatch extra credit

### DIFF
--- a/src/exercise/02.md
+++ b/src/exercise/02.md
@@ -328,23 +328,10 @@ React.useEffect(() => {
 
 [Production deploy](https://advanced-react-hooks.netlify.com/isolated/final/02.extra-3.js)
 
-**NOTICE: Things have changed slightly.** The app you're running the exercises
-in was changed since the videos were recorded and you can no longer see this
-issue by changing the exercise. All the exercises are now rendered in an iframe
-on the exercise pages, so when you go to a different exercise, you're
-effectively "closing" the page, so all JS execution for that exercise stops.
-
-So I've added a little checkbox which you can use to mount and unmount the
-component with ease. This has the benefit of also working on the isolated page
-as well. On the exercise page, you'll want to make sure that your console output
-is showing the output from the iframe by
-[selecting the right context](https://developers.google.com/web/tools/chrome-devtools/console/reference#context).
-
-I've also added a test for this one to help make sure you've got it right.
-
-Also notice that while what we're doing here is still useful and you'll learn
-valuable skills, the warning we're suppressing
-[goes away in React v18](https://github.com/reactwg/react-18/discussions/82).
+**NOTICE: Things have changed.** React 18 has since [deprecated
+the warning](https://github.com/facebook/react/pull/22114) highlighted in this
+exercise. This extra credit has been left here in-case you are **curious only**. You
+**should not** expect to be able to reproduce the scenario as described in the exercise.
 
 Phew, ok, back to your extra credit!
 


### PR DESCRIPTION
Since this project adopted React 18 the safe dispatch extra credit is no longer reproducible. This PR updates the exercise description to inform the reader.