### PR TITLE
Little copy changes

### DIFF
--- a/src/exercise/02.md
+++ b/src/exercise/02.md
@@ -317,7 +317,7 @@ React.useEffect(() => {
     return
   }
   // 💰 note the absence of `await` here. We're literally passing the promise
-  // to `run` so `useAsync` can attach it's own `.then` handler on it to keep
+  // to `run` so `useAsync` can attach its own `.then` handler on it to keep
   // track of the state of the promise.
   const pokemonPromise = fetchPokemon(pokemonName)
   run(pokemonPromise)

--- a/src/exercise/03.md
+++ b/src/exercise/03.md
@@ -59,7 +59,7 @@ show you how to avoid that from happening.
 solution to Prop Drilling pains and it's not necessarily the best solution
 either. React's composition model is powerful and can be used to avoid issues
 with prop drilling as well. Learn more about this from
-[Michael Jackson on Twitter](https://twitter.com/mjackson/status/1195495535483817984)
+[Michael Jackson on X](https://x.com/mjackson/status/1195495535483817984)
 
 ## Exercise
 

--- a/src/exercise/04.js
+++ b/src/exercise/04.js
@@ -78,7 +78,7 @@ const allMessages = [
   `Han: It's worse.`,
   `Luke: There's something alive in here!`,
   `Han: That's your imagination.`,
-  `Luke: Something just moves past my leg! Look! Did you see that?`,
+  `Luke: Something just moved past my leg! Look! Did you see that?`,
   `Han: What?`,
   `Luke: Help!`,
   `Han: Luke! Luke! Luke!`,

--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -78,8 +78,8 @@ function useCount({initialCount = 0, step = 1} = {}) {
 
 This is only really useful for situations where computing the debug value is
 computationally expensive (and therefore you only want it calculated when the
-DevTools are open and not when your users are using the app). In our case this
-is not necessary, however, go ahead and give it a try anyway.
+DevTools are open). In our case this is not necessary, however, go ahead and
+give it a try anyway.
 
 ## 🦉 Feedback
 


### PR DESCRIPTION
I was going through this workshop and noticed a few little typos. Feel free to close if you like, I promise I won't be offended :)

1. fa8f107fcefdbdf9e77a200f21f15c0f12afe2f8: Classic "it's" vs "its" thing. D'oh!
2. 8fb44aafa644b67ee515ee625503e17987958fe4: Changing "Twitter" -> "X" -- the old link works for now, but better safe than sorry
3. fcf00e2f01e92894b10f0d1c1905f5c4627ac54e: Just a goofy typo... and an excuse to take a Star Wars break. If you could use one too, here's a Brazilian journalist doing a Chewbacca impression while reporting on the sad news of Carrie Fisher passing: https://www.youtube.com/watch?v=nzkLPUOiLgQ
4. aac02f3a589475f1573f8436826c036c39f2e42a: Since `useDebugValue` is stubbed out in production builds anyway, I deleted the note about improving its performance for prod users

If this is helpful, I may open other similar PR's as I work through the other workshops in the course